### PR TITLE
Adding documentation reference in help()

### DIFF
--- a/cson/__init__.py
+++ b/cson/__init__.py
@@ -1,3 +1,8 @@
+"""
+A Coffescript Object Notation (CSON) parser for Python 2 and Python 3.
+See documentation at https://github.com/avaka/pycson
+"""
+
 from .parser import load, loads
 from .writer import dump, dumps
 from speg import ParseError


### PR DESCRIPTION
Should fix #13

`help(cson)` now shows link to the source repository where documentation
is available